### PR TITLE
Generate overlays that add cabal options from configuration files

### DIFF
--- a/haskell-overridez
+++ b/haskell-overridez
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+KNOWN_OPTS="doJailbreak dontCheck dontHaddock"
+
 haskell-overridez() {
     OPTIND=1
     local working_dir=$(pwd)
@@ -89,6 +91,14 @@ Usage:
   haskell-overridez -h
     # Show this help message
 
+  HOZ_OPTS=<option-name-1>:<option-name-2> haskell-overridez ...
+    # Apply one of the recognized cabal options when using the override
+    #
+    # The recognized cabal options are:
+    #  doJailbreak:   ignore any incorrect dependency bounds
+    #  dontCheck:     don't run the package's tests
+    #  dontHaddock:   don't build the package documentation
+
 Examples:
 
   haskell-overridez https://github.com/tathougies/beam --subpath beam-core
@@ -96,6 +106,9 @@ Examples:
 
   haskell-overridez -g reflex-frp/reflex-dom-contrib
     # Install add the reflex-dom-contrib package
+
+  HOZ_OPTS=doJailbreak:noCheck haskell-overridez -g reflex-frp/reflex-dom
+    # Adds reflex-dom, ignoring bounds checks without running its tests
 
 EOF
 }
@@ -105,8 +118,9 @@ _delete_if_present() {
     [[ -z $project ]] && { >&2 _show_usage; return 1; }
     local github_file="$(pwd)/nix/git-json/${project}.json"
     local cabal2nix_file="$(pwd)/nix/nix-expr/${project}.nix"
-    [[ -f ${github_file} ]] && rm -v ${github_file}
-    [[ -f ${cabal2nix_file} ]] && rm -v ${cabal2nix_file}
+    [[ -f ${github_file} ]] && rm ${github_file} && _echo "removed github json for $project"
+    [[ -f ${cabal2nix_file} ]] && rm ${cabal2nix_file}  && _echo "removed nix-expr for $project"
+    _maybe_remove_option $project
     return 0
 }
 
@@ -142,8 +156,10 @@ _save_github_json() {
     local out="$(pwd)/nix/git-json/${project##*/}.json"
     _ensure_parent_dir $out
     _init_project
+    _echo "cmd is nix-prefetch-git $url $revision"
     nix-prefetch-git $url $revision > $out && {
-        >&2 echo "Saved github json for ${project} to ${out}"
+        _echo "saved github json for ${project} to ${out}"
+        _maybe_add_options $project
     }
 }
 
@@ -151,18 +167,17 @@ _save_cabal2nix() {
     local pkg_uri=${1:-''}
     shift
     [[ -z $pkg_uri ]] && { >&2 _show_usage; return 1; }
-    echo "cmd is cabal2nix $pkg_uri $@"
-    local nix_expr_tmp=$(mktemp -q) && {
-        cabal2nix $pkg_uri "$@" > $nix_expr_tmp && {
-            local project=$(cat $nix_expr_tmp | grep 'pname' | sed -e 's/.*pname = "\(.*\)".*/\1/')
-            local out="$(pwd)/nix/nix-expr/${project}.nix"
-            _ensure_parent_dir $out
-            _init_project
-            cp $nix_expr_tmp $out
-            >&2 echo "Saved nix-expr for ${project} to ${out}"
-            rm $nix_expr_tmp
-        }
-    }
+    _echo "cmd is cabal2nix $pkg_uri $@"
+    local nix_expr_tmp=$(mktemp -q)
+    trap "rm $nix_expr_tmp" INT TERM EXIT
+    cabal2nix $pkg_uri "$@" > $nix_expr_tmp
+    local project=$(cat $nix_expr_tmp | grep 'pname' | sed -e 's/.*pname = "\(.*\)".*/\1/')
+    local out="$(pwd)/nix/nix-expr/${project}.nix"
+    _ensure_parent_dir $out
+    _init_project
+    cp $nix_expr_tmp $out
+    _echo "saved nix-expr for ${project} to ${out}"
+    _maybe_add_options $project
 }
 
 _list_overrides() {
@@ -184,6 +199,51 @@ _list_overrides() {
 _ensure_parent_dir() {
     local path=$1
     mkdir -p $(dirname $path)
+}
+
+_maybe_add_options() {
+    [[ -z $HOZ_OPTS ]] && return 0
+    local project=${1:-''}
+    [[ -z $project ]] && return 0
+    local hoz_opts_array=(${HOZ_OPTS//:/ })
+    for opt_name in ${hoz_opts_array[@]}
+    do
+        local used=0
+        for known_opt in $KNOWN_OPTS
+        do
+            [[ $opt_name == $known_opt ]] && {
+                _add_option $opt_name $project
+                used=1
+            }
+        done
+        (( used == 0)) && _echo "ignored unrecognized option: $opt_name"
+    done
+}
+
+_add_option() {
+    local opt_name=${1:-''}
+    local project=${2:-''}
+    [[ -z $project ]] && { >&2 _show_usage; return 1; }
+    local out="$(pwd)/nix/options/${opt_name}"
+    _ensure_parent_dir $out
+    [[ -f $out ]] || { echo $project >> $out ; return 0; }
+    sed -i'' -e "/${project}\$/d" $out
+    echo $project >> $out
+    _echo "configured option $opt_name for $project"
+}
+
+_maybe_remove_option() {
+    local project=${1:-''}
+    [[ -z $project ]] && return 0
+    for opt_name in $KNOWN_OPTS
+    do
+        local out="$(pwd)/nix/options/${opt_name}"
+        [[ -f $out ]] && sed -i'' -e "/${project}$/d" $out
+    done
+}
+
+_echo() {
+  >&2 echo "haskell-overridez: $@"
 }
 
 haskell-overridez "$@"


### PR DESCRIPTION
Adds a function that generates a series of overlay functions that apply a cabal
option.

Based on the ideas in
https://github.com/Gabriel439/haskell-nix/tree/master/project4, but with the
lists of names for each overlay coming from files in the nix/options
subdirectory of a project