### PR TITLE
Make projects use the github master version of the nixexpr functions

### DIFF
--- a/haskell-overridez
+++ b/haskell-overridez
@@ -127,20 +127,15 @@ _delete_if_present() {
 _init_project() {
     local out="$(pwd)/nix/haskell-overridez.nix"
     [[ -f $out ]] && return 0;
-    local git_url="https://github.com/adetokunbo/haskell-overridez"
-    local init_tmp=$(mktemp -q)
-    trap "rm $init_tmp" INT TERM EXIT
-    nix-prefetch-git ${git_url} > ${init_tmp}
-    local git_rev=$(cat $init_tmp | grep 'rev' | sed -e 's/.*"rev": "\(.*\)".*/\1/')
-    local git_sha256=$(cat $init_tmp | grep 'sha256' | sed -e 's/.*"sha256": "\(.*\)".*/\1/')
+    local archive_url="https://github.com/adetokunbo/haskell-overridez/archive/master.tar.gz"
+    local the_hash=$(nix-prefetch-url --unpack ${archive_url})
     _ensure_parent_dir $out
     (cat <<EOF
 let
   pkgs = import <nixpkgs> {};
-  overridez = pkgs.fetchgit {
-    url = "${git_url}";
-    rev = "${git_rev}";
-    sha256 = "${git_sha256}";
+  overridez = fetchTarball {
+    url = "${archive_url}";
+    sha256 = "${the_hash}";
   };
 in
   import overridez { inherit pkgs; }


### PR DESCRIPTION
Fixes #5 

Currently new haskell-overridez projects
1) load the support functions using import-from-derivation, importing
  the support functions directly from github
2) the script makes this use the latest commit on github

This changes 2) to use only the latest master version on github.

While this is not as good as using specific versions, it is a big improvement.
The master branch is not the default branch (develop), and only has a latest
"released" version, i.e, it is a lot more stable.

It also means that the script installation instructions and the project
initialization now use the same version.