### PR TITLE
Reenable the github json fixture.

### DIFF
--- a/fixtures/rokubanme-no-purojekuto/SKIP
+++ b/fixtures/rokubanme-no-purojekuto/SKIP
@@ -1,1 +1,0 @@
-bug: there is an infinite recursion when loading the nix project

--- a/fixtures/rokubanme-no-purojekuto/setup_test.sh
+++ b/fixtures/rokubanme-no-purojekuto/setup_test.sh
@@ -7,10 +7,14 @@ setup_test() {
     pushd $this_dir > /dev/null
 
     HOZ_OPTS=dontCheck
-    haskell-overridez -g pcapriotti/optparse-applicative
+
+    # Using -g with optparse-applicative causes infinite recursion
+    haskell-overridez https://github.com/pcapriotti/optparse-applicative
+
     HOZ_OPTS=doJailbreak
     haskell-overridez -g Gabriel439/Haskell-Turtle-Library
     haskell-overridez -g Gabriel439/Haskell-Foldl-Library
+    haskell-overridez -g Gabriel439/Haskell-Managed-Library
 
     popd > /dev/null
     set +x


### PR DESCRIPTION
This made possible by installing optparse-applicative override directly
with cabal2nix instead of with github json file.

The github json file approach does not work using as that causes an infinite
recursion.
(See https://github.com/adetokunbo/haskell-overridez/issues/27)