### PR TITLE
Fix the hackage build.

### DIFF
--- a/haskell-overridez.cabal
+++ b/haskell-overridez.cabal
@@ -37,5 +37,5 @@ executable haskell-overridez
                   , system-filepath      == 0.4.14
                   , system-fileio        == 0.3.16.3
                   , text                 >= 1.2.3 && < 1.3
-                  , turtle               >= 1.5.7 && < 1.7
+                  , turtle               >= 1.5.7 && < 1.5.8
                   , Cabal                >= 2.2.0.1


### PR DESCRIPTION
The bounds for the turtle dependency were too liberal and broke on hackage.

Fixes #56 